### PR TITLE
fix: Handle special characters in database URL for Alembic

### DIFF
--- a/.cursor/rules/linting-formatting.mdc
+++ b/.cursor/rules/linting-formatting.mdc
@@ -1,0 +1,15 @@
+---
+description: Auto-run linters and formatters after code changes
+globs:
+  - "**/*.py"
+alwaysApply: true
+---
+
+- After ANY code change to Python files, automatically run these commands in sequence:
+  1. `uv run ruff check --fix .` (auto-fixes linting issues)
+  2. `uv run black .` (formats code)
+  3. `uv run mypy .` (type checking - no fix option, but must pass)
+
+- If any of these commands fail, fix the issues before proceeding.
+- Run all three commands even if only one file was changed (they're fast).
+- Only skip if the user explicitly requests otherwise.

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,6 +1,6 @@
 from logging.config import fileConfig
 
-from sqlalchemy import engine_from_config, pool
+from sqlalchemy import pool
 from sqlalchemy.engine import create_engine
 
 from alembic import context


### PR DESCRIPTION
- Remove config.set_main_option() which fails with % in passwords
- Use create_engine() directly with settings.postgres_url
- Bypasses ConfigParser interpolation issues
- Fixes ValueError: invalid interpolation syntax with URL-encoded passwords