### PR TITLE
Trigger pipeline when workflow file changes

### DIFF
--- a/.github/workflows/deploy-ecs-jobs.yml
+++ b/.github/workflows/deploy-ecs-jobs.yml
@@ -63,10 +63,21 @@ jobs:
           echo "Changed files:"
           echo "$CHANGED_FILES"
           
+          # Check if workflow file itself changed
+          WORKFLOW_CHANGED=false
+          if echo "$CHANGED_FILES" | grep -q "^\.github/workflows/deploy-ecs-jobs\.yml"; then
+            WORKFLOW_CHANGED=true
+            echo "✅ Workflow file changed - will trigger full pipeline"
+          fi
+          
           # Check if terraform files changed
           if echo "$CHANGED_FILES" | grep -q "^infrastructure/terraform/"; then
             echo "terraform_changed=true" >> $GITHUB_OUTPUT
             echo "✅ Terraform files changed"
+          elif [ "$WORKFLOW_CHANGED" = "true" ]; then
+            # If workflow changed, also check terraform (for safety)
+            echo "terraform_changed=true" >> $GITHUB_OUTPUT
+            echo "✅ Terraform check triggered due to workflow change"
           else
             echo "terraform_changed=false" >> $GITHUB_OUTPUT
             echo "ℹ️  No terraform changes"
@@ -76,6 +87,10 @@ jobs:
           if echo "$CHANGED_FILES" | grep -qE "^(jobs/|app/|ingest/)"; then
             echo "jobs_changed=true" >> $GITHUB_OUTPUT
             echo "✅ Job/app files changed"
+          elif [ "$WORKFLOW_CHANGED" = "true" ]; then
+            # If workflow changed, also check jobs (for safety)
+            echo "jobs_changed=true" >> $GITHUB_OUTPUT
+            echo "✅ Jobs check triggered due to workflow change"
           else
             echo "jobs_changed=false" >> $GITHUB_OUTPUT
             echo "ℹ️  No job/app changes"


### PR DESCRIPTION
## Problem

When the `deploy-ecs-jobs.yml` workflow file itself is changed, the pipeline wasn't triggering because the change detection logic only checked for terraform and job/app file changes.

## Solution

Updated the "Detect changes" step to:
1. **Detect when the workflow file changes** - Checks if `.github/workflows/deploy-ecs-jobs.yml` is in the changed files
2. **Trigger full pipeline** - When workflow file changes, triggers both terraform and jobs checks
3. **Maintain existing behavior** - Still detects terraform and job/app changes as before

## Changes

- Added workflow file change detection
- When workflow file changes, sets both `terraform_changed=true` and `jobs_changed=true`
- Ensures pipeline runs to validate workflow changes

## Testing

Now when you change `deploy-ecs-jobs.yml`:
- ✅ Pipeline will trigger automatically
- ✅ Both terraform and jobs will be checked
- ✅ Full deployment pipeline will run

This ensures workflow changes are properly tested in CI/CD.