### PR TITLE
feat: add AWS credentials validation to email service testing

### DIFF
--- a/EMAIL_SETUP_README.md
+++ b/EMAIL_SETUP_README.md
@@ -17,6 +17,26 @@ TEST_EMAIL_RECIPIENT=your-verified-email@example.com
 
 ℹ️ **Note**: `TEST_EMAIL_RECIPIENT` defaults to `test@example.com` for development/testing. Set it in your `.env` file for production use with a verified email address.
 
+## Prerequisites
+
+### AWS Credentials Setup
+Before testing emails, you need AWS credentials with SES permissions:
+
+```bash
+# Option 1: Environment variables
+export AWS_ACCESS_KEY_ID=your-access-key
+export AWS_SECRET_ACCESS_KEY=your-secret-key
+export AWS_DEFAULT_REGION=us-east-1
+
+# Option 2: AWS CLI configuration
+aws configure
+
+# Verify credentials work
+aws sts get-caller-identity
+```
+
+**Note**: For EC2/production, IAM roles are used automatically - no credentials needed in `.env`.
+
 ## AWS SES Setup Steps
 
 ### 1. Domain Verification

--- a/app/scripts/send_test_email.py
+++ b/app/scripts/send_test_email.py
@@ -10,6 +10,22 @@ from app.services.email_service import get_email_service
 
 def send_test_email():
     """Send a test email to verify email service configuration."""
+    print("🔧 Checking AWS credentials...")
+    try:
+        import boto3
+
+        sts = boto3.client("sts")
+        sts.get_caller_identity()
+        print("✅ AWS credentials verified")
+    except Exception as e:
+        print("❌ AWS credentials not found!")
+        print("   Please set up AWS credentials:")
+        print("   export AWS_ACCESS_KEY_ID=your-key")
+        print("   export AWS_SECRET_ACCESS_KEY=your-secret")
+        print("   export AWS_DEFAULT_REGION=us-east-1")
+        print(f"   Error: {e}")
+        return
+
     try:
         # Get the email service
         service = get_email_service()


### PR DESCRIPTION
## Overview

This PR adds improvements to the email service testing and documentation. This is a follow-up to the merged PR #101 (Phase 2 - Email Service Abstraction).

## ✅ Changes Included

### **Enhanced Test Email Script**
- Added AWS credentials validation before attempting to send emails
- Provides helpful error messages when credentials are missing
- Clear setup instructions for developers
- Prevents cryptic boto3 errors

### **Updated Documentation**
- Added AWS credentials setup section to `EMAIL_SETUP_README.md`
- Clear prerequisites for local email testing
- Production deployment notes with IAM role information

### **Better Developer Experience**
- Test script now fails fast with helpful messages
- No more "Unable to locate credentials" confusion
- Clear guidance for both local development and production

## 📋 Files Changed

- `app/scripts/send_test_email.py` - Added credential validation and error handling
- `EMAIL_SETUP_README.md` - Added AWS credentials setup guide

## 🧪 Testing

```bash
# Test the improved script (will show credential setup if missing)
make send-test-email
```

## 🚀 Ready for Review

This builds on the already merged email service implementation from PR #101 and adds the missing developer experience improvements for local testing.

**Related**: Follows up on #89 (Phase 2 - Email Service Abstraction)