### PR TITLE
Improve dark mode readability for email

### DIFF
--- a/app/templates/email/_base.html
+++ b/app/templates/email/_base.html
@@ -4,6 +4,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="color-scheme" content="light dark">
+    <meta name="supported-color-schemes" content="light dark">
     <title>{{ company_name }} Daily Briefing</title>
     <style>
         body {
@@ -154,6 +156,18 @@
             border: 1px dashed #d1d5db;
             color: #4b5563;
         }
+        .text-body {
+            color: #1f2937;
+        }
+        .text-secondary {
+            color: #374151;
+        }
+        .text-muted {
+            color: #6b7280;
+        }
+        .text-muted-light {
+            color: #9ca3af;
+        }
         @media (max-width: 600px) {
             .email-content { padding: 20px; }
             .ticker-header { flex-direction: column; align-items: flex-start; gap: 8px; }
@@ -165,6 +179,9 @@
             body {
                 background-color: #0f172a;
                 color: #f1f5f9;
+            }
+            a {
+                color: #93c5fd;
             }
             .email-container {
                 background-color: #1e293b;
@@ -186,6 +203,14 @@
             }
             .articles .article {
                 border-color: #334155;
+            }
+            .text-body,
+            .text-secondary {
+                color: #e2e8f0 !important;
+            }
+            .text-muted,
+            .text-muted-light {
+                color: #cbd5f5 !important;
             }
         }
     </style>

--- a/app/templates/email/daily_briefing.html
+++ b/app/templates/email/daily_briefing.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <p style="font-size:16px; margin-bottom:8px;">Hi {{ greeting_name }},</p>
-<p style="font-size:16px; color:#374151; margin-bottom:24px;">
+<p class="text-secondary" style="font-size:16px; margin-bottom:24px;">
     Here is your personalized {{ company_name }} briefing for <strong>{{ date_display }}</strong>
     ({{ timezone }}).
 </p>
@@ -63,12 +63,12 @@
             </table>
             {% if ticker.summary %}
                 <div style="margin-bottom:12px;">
-                    <p style="font-size:15px; line-height:1.6; color:#1f2937;">{{ ticker.summary }}</p>
+                    <p class="text-body" style="font-size:15px; line-height:1.6;">{{ ticker.summary }}</p>
                 </div>
             {% endif %}
 
             {% if ticker.bullets %}
-                <ul style="padding-left:18px; color:#374151; margin-bottom:12px;">
+                <ul class="text-body" style="padding-left:18px; margin-bottom:12px;">
                     {% for bullet in ticker.bullets %}
                         <li style="margin-bottom:6px;">{{ bullet }}</li>
                     {% endfor %}
@@ -77,7 +77,7 @@
 
             {% if ticker.top_articles %}
                 <div class="articles">
-                    <div style="font-size:13px; text-transform:uppercase; letter-spacing:0.08em; color:#9ca3af; margin-bottom:8px;">
+                    <div class="text-muted-light" style="font-size:13px; text-transform:uppercase; letter-spacing:0.08em; margin-bottom:8px;">
                         Top Articles
                     </div>
                     {% for article in ticker.top_articles %}
@@ -101,7 +101,7 @@
                     {% endfor %}
                 </div>
             {% else %}
-                <p style="font-size:13px; color:#6b7280; margin:0;">
+                <p class="text-muted" style="font-size:13px; margin:0;">
                     No highlighted articles available for this ticker today.
                 </p>
             {% endif %}
@@ -116,10 +116,10 @@
     </div>
 {% endif %}
 
-<p style="font-size:14px; color:#6b7280; margin-top:32px;">
+<p class="text-muted" style="font-size:14px; margin-top:32px;">
     Want to update your watchlist? Visit <a href="{{ app_base_url }}">{{ app_base_url }}</a>.
 </p>
-<p style="font-size:14px; color:#6b7280;">
+<p class="text-muted" style="font-size:14px;">
     Stay informed with {{ company_name }}.
 </p>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add explicit color-scheme metadata plus reusable text utility classes so email templates can react to light and dark themes
- apply the new utility classes throughout the daily briefing template to remove inline colors that forced unreadable text in dark mode

## Testing
- `uv run ruff check .`
- `uv run black .`
- `uv run mypy`
- `uv run pytest` *(fails: integration-style tests expect a running Postgres instance on localhost:5432)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918b96ebc7c8329b8744297db07ae03)