### PR TITLE
Add TEST_EMAIL_RECIPIENT to ECS task definition via Secrets Manager

### DIFF
--- a/infrastructure/terraform/ecs.tf
+++ b/infrastructure/terraform/ecs.tf
@@ -369,6 +369,10 @@ resource "aws_ecs_task_definition" "send_daily_emails" {
       {
         name      = "AWS_SES_REGION"
         valueFrom = data.aws_secretsmanager_secret.aws_ses_region.arn
+      },
+      {
+        name      = "TEST_EMAIL_RECIPIENT"
+        valueFrom = data.aws_secretsmanager_secret.test_email_recipient.arn
       }
     ]
 

--- a/infrastructure/terraform/secrets.tf
+++ b/infrastructure/terraform/secrets.tf
@@ -38,3 +38,7 @@ data "aws_secretsmanager_secret" "email_from_address" {
 data "aws_secretsmanager_secret" "aws_ses_region" {
   name = "${var.project_name}/aws-ses-region"
 }
+
+data "aws_secretsmanager_secret" "test_email_recipient" {
+  name = "${var.project_name}/test-email-recipient"
+}


### PR DESCRIPTION
## Summary

Fixes the issue where the `send-daily-emails` job was using the default `test@example.com` instead of the configured test email recipient. The job was failing because it couldn't find the default email in the database.

## Changes

- Added `test_email_recipient` secret data source in `secrets.tf`
- Updated `send_daily_emails` ECS task definition to include `TEST_EMAIL_RECIPIENT` from AWS Secrets Manager
- Follows the same pattern as other email configurations (`email_from_address`, `aws_ses_region`)

## Required Setup

Before applying this Terraform change, create the secret in AWS Secrets Manager:

```bash
aws secretsmanager create-secret \
  --name market-pulse/test-email-recipient \
  --secret-string "alextesy@gmail.com" \
  --region us-east-1
```

Or if it already exists, update it:

```bash
aws secretsmanager put-secret-value \
  --secret-id market-pulse/test-email-recipient \
  --secret-string "alextesy@gmail.com" \
  --region us-east-1
```

## Testing

After applying Terraform and creating the secret, the ECS task will have access to `TEST_EMAIL_RECIPIENT` from Secrets Manager, and the job will use the configured email instead of the default.

## Related

Fixes the error: `TEST_EMAIL_RECIPIENT (test@example.com) not found in database`