### PR TITLE
Guard enum sentiment values in test

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1024,6 +1024,9 @@ async def get_all_tickers(
 
     db = SessionLocal()
     try:
+        # Normalize search input to handle accidental whitespace
+        search = search.strip() if search else None
+
         # Calculate pagination with clamps and offset guard
         limit = min(limit, settings.MAX_LIMIT_TICKERS)
         offset = (page - 1) * limit
@@ -1191,9 +1194,11 @@ async def browse_tickers(
 ) -> HTMLResponse:
     """Browse all tickers with pagination and search."""
 
+    normalized_search = search.strip() if search else None
+
     # Get ticker data via API endpoint logic
     api_data = await get_all_tickers(
-        page=page, search=search, sort_by=sort_by, limit=50
+        page=page, search=normalized_search, sort_by=sort_by, limit=50
     )
 
     followed_tickers: list[str] = []
@@ -1223,7 +1228,7 @@ async def browse_tickers(
             "request": request,
             "tickers": api_data["tickers"],
             "pagination": api_data["pagination"],
-            "search": search or "",
+            "search": normalized_search or "",
             "sort_by": sort_by,
             "followed_tickers": followed_tickers,
         },

--- a/test_enum_serialization.py
+++ b/test_enum_serialization.py
@@ -48,6 +48,7 @@ def test_enum_serialization():
 
         print("\nSaving to database...")
         created = repo.upsert_summary(dto)
+        assert created.llm_sentiment is not None
         print(f"✓ Successfully saved! ID: {created.id}")
         print(f"✓ Sentiment enum: {created.llm_sentiment}")
         print(f"✓ Sentiment value: {created.llm_sentiment.value}")
@@ -62,6 +63,7 @@ def test_enum_serialization():
         )
 
         if entity:
+            assert entity.llm_sentiment is not None
             print("\n✓ Verified in database:")
             print(f"  - Sentiment enum: {entity.llm_sentiment}")
             print(f"  - Sentiment value: {entity.llm_sentiment.value}")
@@ -91,6 +93,7 @@ def test_enum_serialization():
                 llm_model="gpt-test",
             )
             result = repo.upsert_summary(test_dto)
+            assert result.llm_sentiment is not None
             print(
                 f"✓ {sentiment_enum.name} -> {sentiment_enum.value} (saved as ID: {result.id})"
             )


### PR DESCRIPTION
## Summary
- assert sentiment values are present before accessing enum attributes in the enum serialization test to satisfy mypy

## Testing
- uv run ruff check .
- uv run black .
- uv run mypy .
- uv run pytest *(fails: integration tests require Postgres connection on localhost:5432; reddit scraper status test expects DB data)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f5f60af8c8329a4536f5a1958403c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Trims whitespace from ticker search input in API/UI and adds non-null assertions for enum sentiment in the serialization test.
> 
> - **Tickers (API/UI)**:
>   - Normalize/trim `search` input in `get_all_tickers` and `browse_tickers`, pass normalized value, and render it in `browse.html` context.
> - **Tests**:
>   - Add `assert ... is not None` checks for `llm_sentiment` in `test_enum_serialization.py` (creation, DB fetch, and enum loop).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e37eb25c1b43b6b07010e066b90d3166d0c0169. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->